### PR TITLE
Missing extension in module name is added for Ubuntu 18.04/bionic

### DIFF
--- a/spatialite/connection.py
+++ b/spatialite/connection.py
@@ -9,6 +9,7 @@ class Connection(sqlite3.Connection):
 
     EXT_NAMES = (
         'mod_spatialite',  # Ubuntu
+        'mod_spatialite.so',  # Ubuntu
         'mod_spatialite.dylib',  # macOS
     )
 


### PR DESCRIPTION
To solve `sqlite3.OperationalError: The specified module could not be found` error in Ubuntu 18.04, `.so` extension is added to module name.